### PR TITLE
Fix links in popup.html

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -64,19 +64,15 @@
         <h3 data-value="BetterKabu">BetterKabu</h3>
         <p>Verwandelt Digikabu in BetterKabu.</p>
         <div>
-            <a id="github" class="meta-link" href="https://github.com/ouihq/better-kabu" target="_blank">
+            <a id="github" class="meta-link" href="https://github.com/ouihq/betterKabu" target="_blank">
                 <i class=""></i>
                 <span>Source</span>
-            </a>
-            <a id="personal" class="meta-link" href="https://ouihq.me" target="_blank">
-                <i class=""></i>
-                <span>Website</span>
             </a>
             <a id="donate" class="meta-link" href="https://www.buymeacoffee.com/ouihq" target="_blank">
                 <i class=""></i>
                 <span>Donate</span>
             </a>
-            <a id="rate" class="meta-link" href="https://chrome.google.com/webstore/detail/betterkabu/ipjhihpfmeboghcbncneiheafcpodcin?hl=de" target="_blank">
+            <a id="rate" class="meta-link" href="https://chrome.google.com/webstore/detail/betterkabu/ipjhihpfmeboghcbncneiheafcpodcin" target="_blank">
                 <i class=""></i>
                 <span>Rate</span>
             </a>


### PR DESCRIPTION
### Summary
This PR updates and cleans up the links in `popup.html`:

### Changes
- Replaces the outdated source link with the correct one.
- Removes `https://ouihq.me` as the domain is offline.
- Eliminates the default locale for the Chrome extension link to ensure proper navigation.


